### PR TITLE
Add chess game with AI and online play

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "chess-game",
+  "version": "1.0.0",
+  "description": "Simple chess game with AI and online play",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "socket.io": "^4.7.2"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Jogo de Xadrez</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.jsdelivr.net/npm/chess.js@1.0.0/chess.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/socket.io-client@4/dist/socket.io.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chessboardjs@1.0.0/dist/chessboard-1.0.0.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/chessboardjs@1.0.0/dist/chessboard-1.0.0.min.css" />
+</head>
+<body>
+    <h1>Jogo de Xadrez</h1>
+    <div id="mode-select">
+        <button id="vs-ai">Jogar contra IA</button>
+        <button id="vs-online">Jogar online</button>
+    </div>
+    <div id="board" style="width: 400px"></div>
+    <div id="status"></div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,92 @@
+const boardElement = document.getElementById('board');
+const statusEl = document.getElementById('status');
+const vsAiBtn = document.getElementById('vs-ai');
+const vsOnlineBtn = document.getElementById('vs-online');
+
+let board = null;
+let game = new Chess();
+let socket = null;
+let room = null;
+let vsAI = false;
+
+function updateStatus() {
+  let status = '';
+  let moveColor = game.turn() === 'b' ? 'Pretas' : 'Brancas';
+  if (game.in_checkmate()) {
+    status = 'Fim de jogo, ' + moveColor + ' estão em cheque-mate.';
+  } else if (game.in_draw()) {
+    status = 'Empate!';
+  } else {
+    status = 'Vez das ' + moveColor + (game.in_check() ? ' (em cheque)' : '');
+  }
+  statusEl.innerHTML = status;
+}
+
+function onDragStart(source, piece) {
+  if (game.game_over()) return false;
+  if (!vsAI && socket && game.turn() === 'w' && piece.search(/^b/) !== -1) return false;
+  if (!vsAI && socket && game.turn() === 'b' && piece.search(/^w/) !== -1) return false;
+}
+
+function makeRandomMove() {
+  const possibleMoves = game.moves();
+  if (possibleMoves.length === 0) return;
+  const move = possibleMoves[Math.floor(Math.random() * possibleMoves.length)];
+  game.move(move);
+  board.position(game.fen());
+  updateStatus();
+}
+
+function onDrop(source, target) {
+  let move = game.move({ from: source, to: target, promotion: 'q' });
+  if (move === null) return 'snapback';
+  if (socket) {
+    socket.emit('move', { room, move });
+  }
+  updateStatus();
+  if (vsAI && !game.game_over()) {
+    window.setTimeout(makeRandomMove, 250);
+  }
+}
+
+function startGameAI() {
+  game.reset();
+  vsAI = true;
+  if (socket) {
+    socket.disconnect();
+    socket = null;
+  }
+  board = Chessboard('board', {
+    draggable: true,
+    position: 'start',
+    onDragStart: onDragStart,
+    onDrop: onDrop,
+    onSnapEnd: () => board.position(game.fen()),
+  });
+  updateStatus();
+}
+
+function startGameOnline() {
+  vsAI = false;
+  socket = io();
+  room = prompt('Digite o nome da sala:');
+  if (!room) return;
+  socket.emit('join', room);
+  game.reset();
+  board = Chessboard('board', {
+    draggable: true,
+    position: 'start',
+    onDragStart: onDragStart,
+    onDrop: onDrop,
+    onSnapEnd: () => board.position(game.fen()),
+  });
+  socket.on('move', (move) => {
+    game.move(move);
+    board.position(game.fen());
+    updateStatus();
+  });
+  updateStatus();
+}
+
+vsAiBtn.addEventListener('click', startGameAI);
+vsOnlineBtn.addEventListener('click', startGameOnline);

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,11 @@
+body {
+    font-family: Arial, sans-serif;
+    text-align: center;
+    background: #f0f0f0;
+}
+#mode-select {
+    margin-bottom: 20px;
+}
+#status {
+    margin-top: 10px;
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+const path = require('path');
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server);
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+io.on('connection', (socket) => {
+  socket.on('join', (room) => {
+    socket.join(room);
+    socket.to(room).emit('message', 'Opponent joined');
+  });
+
+  socket.on('move', ({ room, move }) => {
+    socket.to(room).emit('move', move);
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => console.log(`Server listening on port ${PORT}`));


### PR DESCRIPTION
## Summary
- create basic Node.js server and client to play chess
- add web UI powered by chessboard.js and chess.js
- allow playing versus simple AI or online opponent

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840ce373a448330b358d51c2f65994c